### PR TITLE
Add `show_diff` Parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,14 @@ Which will produce the following ini file
 
 		**Default**: `true`
 
+	* `show_diff`
+		Boolean to determine if the diff should be reported on a puppet
+        run that changes the file contents
+
+		**Type**: Boolean
+
+		**Default**: `true`
+
 ## Limitations
 
 While this module is flagged as only operating on RedHat and CentOS systems it

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -60,6 +60,9 @@
 #   or not. Some applications using ini sytle configuration files can not handle
 #   leading white space
 #
+# @param show_diff If the diff should be reported on a puppet run that
+#   changes the file contents.
+#
 define ini_config (
   Enum['present', 'absent'] $ensure = 'present',
   String $config_file      = '',
@@ -69,6 +72,7 @@ define ini_config (
   String $group            = 'root',
   Boolean $quotesubsection = true,
   Boolean $indentoptions   = true,
+  Boolean $show_diff       = true,
 ) {
   # Our config file should be either $config_file or $title but it must be an
   # absolute_path
@@ -87,10 +91,11 @@ define ini_config (
   }
 
   file { $file_path:
-    ensure  => $_ensure,
-    owner   => $owner,
-    group   => $group,
-    mode    => $mode,
-    content => template("${module_name}/config.erb"),
+    ensure    => $_ensure,
+    owner     => $owner,
+    group     => $group,
+    mode      => $mode,
+    content   => template("${module_name}/config.erb"),
+    show_diff => $show_diff,
   }
 }

--- a/spec/defines/init_spec.rb
+++ b/spec/defines/init_spec.rb
@@ -18,6 +18,7 @@ describe 'ini_config', :type => :define do
       'group'             => 'bar',
       'quotesubsection'   => true,
       'indentoptions'     => true,
+      'show_diff'         => true,
     }
   }
 
@@ -105,6 +106,13 @@ testvar3 = testvar3
         params.merge!({'ensure' => 'absent'})
         is_expected.to contain_file(title).with(
           :ensure => 'absent',
+        )
+      end
+
+      it "should have a config file with a hidden diff if show_diff is false" do
+        params.merge!({'show_diff' => false})
+        is_expected.to contain_file(title).with(
+          :show_diff => 'false',
         )
       end
     end


### PR DESCRIPTION
Occasionally ini files will contain secrets. These can (and should) be
hidden from the puppet report by setting `show_diff` to false.

Signed-off-by: Trevor Bramwell tbramwell@linuxfoundation.org
